### PR TITLE
minor fix. Update sample.toml field, naming fix

### DIFF
--- a/config/sample.toml
+++ b/config/sample.toml
@@ -31,7 +31,7 @@ session-expire = "1d"
 [api.client]
 # Client-facing API
 service-addr = { host = "0.0.0.0", port = 6021 }
-ssl-enabeld = false
+ssl-enabled = false
 
 
 [api.manager]


### PR DESCRIPTION
Update sample.toml field naming fix.
Causes configuration error.
'ssl-enabeld is not allowed key'