### PR TITLE
Minor fix to comment out purestorage from default backend.

### DIFF
--- a/src/ai/backend/storage/context.py
+++ b/src/ai/backend/storage/context.py
@@ -19,7 +19,7 @@ from .types import VolumeInfo
 
 
 BACKENDS: Mapping[str, Type[AbstractVolume]] = {
-    'purestorage': FlashBladeVolume,
+    # 'purestorage': FlashBladeVolume,
     'vfs': BaseVolume,
 }
 


### PR DESCRIPTION
- There may be developers who do not have pure storage installed. Prevent this error by commenting purestorage out.