### PR TITLE
fix: no operational delete_files method

### DIFF
--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -160,5 +160,10 @@ class AbstractVolume(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    async def delete_files(self, vfid: UUID, relpaths: Sequence[PurePosixPath]) -> None:
+    async def delete_files(
+        self,
+        vfid: UUID,
+        relpaths: Sequence[PurePosixPath],
+        recursive: bool = False
+    ) -> None:
         pass

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -64,7 +64,7 @@ async def download(request: web.Request) -> web.StreamResponse:
     secret = ctx.local_config['storage-proxy']['secret']
     async with check_params(request, t.Dict({
         t.Key('token'): tx.JsonWebToken(secret=secret, inner_iv=download_token_data_iv),
-        t.Key('archive', default=False): t.ToBool | t.Null,
+        t.Key('archive', default=False): t.ToBool,
     }), read_from=CheckParamSource.QUERY) as params:
         async with ctx.get_volume(params['token']['volume']) as volume:
             token_data = params['token']

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -21,6 +21,7 @@ import trafaret as t
 import zipstream
 
 from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.common.types import BinarySize
 from ai.backend.common.utils import AsyncFileWriter
 from ai.backend.common import validators as tx
 
@@ -232,7 +233,7 @@ async def tus_options(request: web.Request) -> web.Response:
     headers["Access-Control-Allow-Methods"] = "*"
     headers["Tus-Resumable"] = "1.0.0"
     headers["Tus-Version"] = "1.0.0"
-    headers["Tus-Max-Size"] = ctx.local_config['storage-proxy']['max-upload-size']
+    headers["Tus-Max-Size"] = str(int(ctx.local_config['storage-proxy']['max-upload-size']))
     headers["X-Content-Type-Options"] = "nosniff"
     return web.Response(headers=headers)
 

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -64,6 +64,7 @@ async def download(request: web.Request) -> web.StreamResponse:
     secret = ctx.local_config['storage-proxy']['secret']
     async with check_params(request, t.Dict({
         t.Key('token'): tx.JsonWebToken(secret=secret, inner_iv=download_token_data_iv),
+        t.Key('archive', default=False): t.ToBool | t.Null,
     }), read_from=CheckParamSource.QUERY) as params:
         async with ctx.get_volume(params['token']['volume']) as volume:
             token_data = params['token']

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -297,8 +297,12 @@ async def delete_files(request: web.Request) -> web.Response:
         t.Key('volume'): t.String(),
         t.Key('vfid'): tx.UUID(),
         t.Key('relpaths'): t.List(tx.PurePath(relative_only=True)),
+        t.Key('recursive', default=False): t.Null | t.ToBool,
     })) as params:
         await log_manager_api_entry(log, 'delete_files', params)
+        ctx: Context = request.app['ctx']
+        async with ctx.get_volume(params['volume']) as volume:
+            await volume.delete_files(params['vfid'], params['relpaths'], params['recursive'])
         return web.json_response({
             'status': 'ok',
         })

--- a/src/ai/backend/storage/api/manager.py
+++ b/src/ai/backend/storage/api/manager.py
@@ -297,7 +297,7 @@ async def delete_files(request: web.Request) -> web.Response:
         t.Key('volume'): t.String(),
         t.Key('vfid'): tx.UUID(),
         t.Key('relpaths'): t.List(tx.PurePath(relative_only=True)),
-        t.Key('recursive', default=False): t.Null | t.ToBool,
+        t.Key('recursive', default=False): t.ToBool,
     })) as params:
         await log_manager_api_entry(log, 'delete_files', params)
         ctx: Context = request.app['ctx']

--- a/src/ai/backend/storage/purestorage/__init__.py
+++ b/src/ai/backend/storage/purestorage/__init__.py
@@ -163,7 +163,12 @@ class FlashBladeVolume(BaseVolume):
         # TODO: pcp ...
         raise NotImplementedError
 
-    async def delete_files(self, vfid: UUID, relpaths: Sequence[PurePosixPath]) -> None:
+    async def delete_files(
+        self,
+        vfid: UUID,
+        relpaths: Sequence[PurePosixPath],
+        recursive: bool = False
+    ) -> None:
         target_paths = [bytes(self.sanitize_vfpath(vfid, p)) for p in relpaths]
         proc = await asyncio.create_subprocess_exec(
             b'prm', *target_paths,

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -8,7 +8,6 @@ import shutil
 from typing import (
     AsyncIterator,
     FrozenSet,
-    Optional,
     Sequence,
     Union,
 )
@@ -276,12 +275,20 @@ class BaseVolume(AbstractVolume):
 
         return _aiter()
 
-    async def delete_files(self, vfid: UUID, relpaths: Sequence[PurePosixPath]) -> None:
+    async def delete_files(
+        self,
+        vfid: UUID,
+        relpaths: Sequence[PurePosixPath],
+        recursive: bool = False
+    ) -> None:
         target_paths = [self.sanitize_vfpath(vfid, p) for p in relpaths]
 
         def _delete() -> None:
             for p in target_paths:
-                p.unlink()
+                if p.is_dir() and recursive:
+                    shutil.rmtree(p)
+                else:
+                    p.unlink()
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _delete)

--- a/src/ai/backend/storage/xfs/agent.py
+++ b/src/ai/backend/storage/xfs/agent.py
@@ -13,9 +13,12 @@ log = BraceStyleAdapter(logging.getLogger('ai.backend.storage.server'))
 
 async def read_file(loop: asyncio.BaseEventLoop, filename: str) -> str:
     content = ''
+
     def _read():
+        nonlocal content
         with open(filename, 'r') as fr:
             content = fr.read()
+
     await loop.run_in_executor(None, _read())
     return content
 


### PR DESCRIPTION
This PR enables `delete_files` API.

Other fixes:
*  `recursive` parameter is introduced to delete a directory.
* Add `archive` parameter in download API.
* `Tus-Max-Size` header should be non-negative integer, but aiohttp requires headers' values to be str. `max-upload-size` is typed as `BinarySize`, which raises following exception, should be converted to str (with size in bytes):

```shell
ERROR Unhandled exception
Traceback (most recent call last):
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 461, in start
await prepare_meth(request)
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/web_response.py", line 353, in prepare
return await self._start(request)
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/web_response.py", line 667, in _start
return await super()._start(request)
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/web_response.py", line 410, in _start
await writer.write_headers(status_line, headers)
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/http_writer.py", line 111, in write_headers
buf = _serialize_headers(status_line, headers)
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/http_writer.py", line 160, in _py_serialize_headers
[k + ': ' + v + '\r\n' for k, v in headers.items()])
File
"/home/adrysn/.pyenv/versions/venv-master-storage-proxy/lib/python3.8/site-packages/aiohttp/http_writer.py", line 160, in <listcomp>
[k + ': ' + v + '\r\n' for k, v in headers.items()])
TypeError: can only concatenate str (not "BinarySize") to str
```