### PR TITLE
fix: add cors option for download API

### DIFF
--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -277,17 +277,17 @@ async def init_client_app(ctx: Context) -> web.Application:
     app = web.Application()
     app['ctx'] = ctx
     cors_options = {
-        '*': aiohttp_cors.ResourceOptions(
+        "*": aiohttp_cors.ResourceOptions(
             allow_credentials=True,
-            allow_methods='*',
+            allow_methods="*",
             expose_headers="*",
             allow_headers="*"
         ),
     }
     cors = aiohttp_cors.setup(app, defaults=cors_options)
-    r = cors.add(app.router.add_resource('/download'))
+    r = cors.add(app.router.add_resource("/download"))
     r.add_route('GET', download)
-    r = cors.add(app.router.add_resource('/upload'))
+    r = cors.add(app.router.add_resource("/upload"))
     r.add_route('OPTIONS', tus_options)
     r.add_route('HEAD',    tus_check_session)
     r.add_route('PATCH',   tus_upload_part)

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -17,6 +17,7 @@ from typing import (
 import urllib.parse
 
 from aiohttp import hdrs, web
+import aiohttp_cors
 import janus
 import trafaret as t
 import zipstream
@@ -275,8 +276,19 @@ async def prepare_tus_session_headers(
 async def init_client_app(ctx: Context) -> web.Application:
     app = web.Application()
     app['ctx'] = ctx
+
+    cors_options = {
+        '*': aiohttp_cors.ResourceOptions(
+            allow_credentials=True,
+            allow_methods='*',
+            expose_headers="*",
+            allow_headers="*"
+        ),
+    }
+    cors = aiohttp_cors.setup(app, defaults=cors_options)
+
     add_route = app.router.add_route
-    add_route('GET',     '/download', download)
+    cors.add(add_route('GET',     '/download', download))
     add_route('OPTIONS', '/upload', tus_options)
     add_route('HEAD',    '/upload', tus_check_session)
     add_route('PATCH',   '/upload', tus_upload_part)

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -276,7 +276,6 @@ async def prepare_tus_session_headers(
 async def init_client_app(ctx: Context) -> web.Application:
     app = web.Application()
     app['ctx'] = ctx
-
     cors_options = {
         '*': aiohttp_cors.ResourceOptions(
             allow_credentials=True,
@@ -286,10 +285,10 @@ async def init_client_app(ctx: Context) -> web.Application:
         ),
     }
     cors = aiohttp_cors.setup(app, defaults=cors_options)
-
-    add_route = app.router.add_route
-    cors.add(add_route('GET',     '/download', download))
-    add_route('OPTIONS', '/upload', tus_options)
-    add_route('HEAD',    '/upload', tus_check_session)
-    add_route('PATCH',   '/upload', tus_upload_part)
+    r = cors.add(app.router.add_resource('/download'))
+    r.add_route('GET', download)
+    r = cors.add(app.router.add_resource('/upload'))
+    r.add_route('OPTIONS', tus_options)
+    r.add_route('HEAD',    tus_check_session)
+    r.add_route('PATCH',   tus_upload_part)
     return app

--- a/src/ai/backend/storage/api/client.py
+++ b/src/ai/backend/storage/api/client.py
@@ -287,7 +287,7 @@ async def init_client_app(ctx: Context) -> web.Application:
     cors = aiohttp_cors.setup(app, defaults=cors_options)
     r = cors.add(app.router.add_resource("/download"))
     r.add_route('GET', download)
-    r = cors.add(app.router.add_resource("/upload"))
+    r = app.router.add_resource("/upload")  # tus handlers handle CORS by themselves
     r.add_route('OPTIONS', tus_options)
     r.add_route('HEAD',    tus_check_session)
     r.add_route('PATCH',   tus_upload_part)


### PR DESCRIPTION
When a browser client (Console) tries to download a file from storage-proxy, it is blocked since CORS policy is not set from the server.