### PR TITLE
fix: unable to delete directories with purestorage backend

### DIFF
--- a/src/ai/backend/storage/purestorage/__init__.py
+++ b/src/ai/backend/storage/purestorage/__init__.py
@@ -247,6 +247,7 @@ class FlashBladeVolume(BaseVolume):
         target_paths = [bytes(self.sanitize_vfpath(vfid, p)) for p in relpaths]
         proc = await asyncio.create_subprocess_exec(
             b"prm",
+            b"-r",
             *target_paths,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
To delete a directory with pure storage backend, we have to use `prm -r` command, not just `prm`.