### PR TITLE
fix: sliently skip deleting errors when physical directory not exists

### DIFF
--- a/changes/29.fix
+++ b/changes/29.fix
@@ -1,0 +1,1 @@
+Sliently skip when physical directory corresponding to a vfolder does not exist in deleting the vfolder.

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -75,7 +75,10 @@ class BaseVolume(AbstractVolume):
         loop = asyncio.get_running_loop()
 
         def _delete_vfolder():
-            shutil.rmtree(vfpath)
+            try:
+                shutil.rmtree(vfpath)
+            except FileNotFoundError:
+                pass
             # remove intermediate prefix directories if they become empty
             if not os.listdir(vfpath.parent):
                 vfpath.parent.rmdir()

--- a/src/ai/backend/storage/xfs/__init__.py
+++ b/src/ai/backend/storage/xfs/__init__.py
@@ -144,7 +144,10 @@ class XfsVolume(BaseVolume):
         vfpath = self.mangle_vfpath(vfid)
 
         def _delete_vfolder():
-            shutil.rmtree(vfpath)
+            try:
+                shutil.rmtree(vfpath)
+            except FileNotFoundError:
+                pass
             if not os.listdir(vfpath.parent):
                 vfpath.parent.rmdir()
             if not os.listdir(vfpath.parent.parent):


### PR DESCRIPTION
Due to this error, a manager cannot remove the vfolder from DB which does not have a corresponding physical directory.