### PR TITLE
refactor: Split out vfolder creation from vfolder clone

### DIFF
--- a/changes/38.fix.md
+++ b/changes/38.fix.md
@@ -1,0 +1,1 @@
+Split vfolder creation from vfolder clone with `exist_ok=True` option to allow separate invocation of those two operations when cloning a vfolder to achieve better asynchrony in the manager side

--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -83,6 +83,8 @@ class AbstractVolume(metaclass=ABCMeta):
         self,
         vfid: UUID,
         options: VFolderCreationOptions = None,
+        *,
+        exist_ok: bool = False,
     ) -> None:
         pass
 

--- a/src/ai/backend/storage/abc.py
+++ b/src/ai/backend/storage/abc.py
@@ -101,9 +101,9 @@ class AbstractVolume(metaclass=ABCMeta):
         options: VFolderCreationOptions = None,
     ) -> None:
         """
-        Create a new vfolder on the destination volume
-        and copy all contents of the source vfolder into it,
-        preserving file permissions and timestamps.
+        Create a new vfolder on the destination volume with
+        ``exist_ok=True`` option and copy all contents of the source
+        vfolder into it, preserving file permissions and timestamps.
         """
         pass
 

--- a/src/ai/backend/storage/netapp/__init__.py
+++ b/src/ai/backend/storage/netapp/__init__.py
@@ -113,18 +113,6 @@ class NetAppVolume(BaseVolume):
             io_usec_write=metric["latency"]["write"],
         )
 
-    async def create_vfolder(
-        self,
-        vfid: UUID,
-        options: VFolderCreationOptions = None,
-    ) -> None:
-        vfpath = self.mangle_vfpath(vfid)
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: vfpath.mkdir(0o755, parents=True, exist_ok=False),
-        )
-
     async def delete_vfolder(self, vfid: UUID) -> None:
         vfpath = self.mangle_vfpath(vfid)
 
@@ -181,7 +169,7 @@ class NetAppVolume(BaseVolume):
             raise VFolderCreationError("Not enough space available for clone")
 
         # create the target vfolder
-        await dst_volume.create_vfolder(dst_vfid, options=options)
+        await dst_volume.create_vfolder(dst_vfid, options=options, exist_ok=True)
 
         # arrange directory based on nfs
         src_vfpath = str(self.mangle_vfpath(src_vfid)).split(

--- a/src/ai/backend/storage/types.py
+++ b/src/ai/backend/storage/types.py
@@ -66,8 +66,11 @@ class VFolderCreationOptions:
         return t.Dict({t.Key("quota", default=None): t.Null | tx.BinarySize})
 
     @classmethod
-    def as_object(cls, dict_opts: Mapping) -> VFolderCreationOptions:
-        quota = dict_opts.get("quota")
+    def as_object(cls, dict_opts: Mapping | None) -> VFolderCreationOptions:
+        if dict_opts is None:
+            quota = None
+        else:
+            quota = dict_opts.get("quota")
         return VFolderCreationOptions(quota=quota)
 
 

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -148,7 +148,7 @@ class BaseVolume(AbstractVolume):
         loop = asyncio.get_running_loop()
         try:
             stat = await loop.run_in_executor(None, metadata_path.stat)
-            if stat.st_size > 10 * (2 ** 20):
+            if stat.st_size > 10 * (2**20):
                 raise RuntimeError("Too large metadata (more than 10 MiB)")
             data = await loop.run_in_executor(None, metadata_path.read_bytes)
             return data

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -17,10 +17,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import BinarySize, HardwareMetadata
 
 from ..abc import CAP_VFOLDER, AbstractVolume
-from ..exception import (
-    ExecutionError,
-    InvalidAPIParameters,
-)
+from ..exception import ExecutionError, InvalidAPIParameters
 from ..types import (
     SENTINEL,
     DirEntry,

--- a/src/ai/backend/storage/vfs/__init__.py
+++ b/src/ai/backend/storage/vfs/__init__.py
@@ -96,7 +96,7 @@ class BaseVolume(AbstractVolume):
         src_vfid: UUID,
         dst_volume: AbstractVolume,
         dst_vfid: UUID,
-        options: VFolderCreationOptions = None,  # ignored; vfolder must be created before.
+        options: VFolderCreationOptions = None,
     ) -> None:
         # check if there is enough space in the destination
         fs_usage = await dst_volume.get_fs_usage()

--- a/src/ai/backend/storage/xfs/__init__.py
+++ b/src/ai/backend/storage/xfs/__init__.py
@@ -150,8 +150,10 @@ class XfsVolume(BaseVolume):
         self,
         vfid: UUID,
         options: VFolderCreationOptions = None,
+        *,
+        exist_ok: bool = False,
     ) -> None:
-        await super().create_vfolder(vfid, options)
+        await super().create_vfolder(vfid, options, exist_ok=exist_ok)
 
         # NOTE: Do we need to register project ID for a directory without quota?
         #       Yes, to easily get the file size and used bytes of a directory.


### PR DESCRIPTION
refs lablup/backend.ai#354

* To keep backward compatibility, call `create_vfolder()` with a new
  option `exist_ok=True` from `clone_vfolder()`, so that the manager
  could create the destination vfolder before calling the clone
  operation.
* Remove the duplicate code of `create_vfolder()` method in the NetApp
  backend.