### PR TITLE
setup: Upgrade backend.ai-common to 21.9 series

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     trafaret>=2.1.0
     uvloop>=0.16.0
     zipstream~=1.1.4
-    backend.ai-common==21.9.7
+    backend.ai-common~=21.9.7
 zip_safe = false
 include_package_data = true
 


### PR DESCRIPTION
**TL;DR** This pull request loosens the range of `backend.ai-common` version that `backend.ai-storage-proxy` depends on.

---

There happens a conflict during `backend.ai` installation:
```zsh
% git clone https://github.com/lablup/backend.ai -b 21.09
% cd backend.ai
backend.ai % ./script/install-dev.sh --server-branch 21.09
.
.
ERROR: Cannot install backend-ai-common 21.9.8 (from /Users/rapsealk/Desktop/git/backend.ai/backend.ai-dev/common) and backend-ai-storage-proxy[build,dev,lint,test,typecheck]==21.9.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested backend-ai-common 21.9.8 (from /Users/rapsealk/Desktop/git/backend.ai/backend.ai-dev/common)
    backend-ai-storage-proxy[build,dev,lint,test,typecheck] 21.9.4 depends on backend.ai-common==21.9.7
```

The conflict point is here:
https://github.com/lablup/backend.ai/blob/82112711cfb11138d219bdfbcc7c8fce351f0414/scripts/install-dev.sh#L615-L618

It seems that this happens because `backend.ai-storage-proxy` strictly depends on the specific version of `backend.ai-common`(21.9.7), while the current (latest) version installed by `backend.ai-common@21.09` branch is `21.9.8`.

Therefore, I changed the version specifier from `==` to `~=`, which is more flexible and still ensures compatibility. It seems okay since the changes on `backend.ai-common@21.9.8` do not affect `backend.ai-storage-proxy`.